### PR TITLE
Fix: Handle error when no response is returned by a handler

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -143,7 +143,7 @@ export const makeHandler = <T extends BaseType>({
           res,
           localNext,
         );
-        if (!res.headersSent && !err) {
+        if (!res.headersSent && !err && output !== void 0) {
           res.send(output as Output<Exclude<typeof result, undefined>>);
         }
       } catch (e) {


### PR DESCRIPTION
This PR fixes an issue where using a handler that does not return a response results in an error:
`Cannot set headers after they are sent to the client.`

This error occurs because the server attempts to send headers and a response body, even though no content is provided. As a result, it becomes impossible to send a response body afterwards. This patch ensures proper handling of such cases to avoid this error.